### PR TITLE
Extend default filter to allow any registered extension to be loaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Installation
 Usage
 -----
 
-Call `createApiTree` to load all .js and .coffee files in the given directory (and its subdirectories) and return an object, such that `returnedObject.foo.bar.boz.fubar` equals to exported function `fubar` of file `boz` in subdirectory `foo/bar` of the given directory. (Some of the described details are customizable via optional callbacks.)
+Call `createApiTree` to load all files in the given directory (and its subdirectories) and return an object, such that `returnedObject.foo.bar.boz.fubar` equals to exported function `fubar` of file `boz` in subdirectory `foo/bar` of the given directory. (Some of the described details are customizable via optional callbacks.)
 
 Example:
 
@@ -32,7 +32,7 @@ createApiTree function accepts 2 arguments:
 where options is an optional object with 3 possible keys:
 
 * `options.loadItem(path)` loads the contents of file at `path`; returns either `null` or an object that will be merged into the tree; the default value is `require`.
-* `options.filter(name, names)` determines whether given file should be processed or ignored; other names from the same directory are provided as the second argument; the default implementation returns true for .js files and for .coffee files which don't have corresponding .js files.
+* `options.filter(name, names)` determines whether given file should be processed or ignored; other names from the same directory are provided as the second argument; the default implementation returns true for .js files and files with a registered extension in require.extensions which don't have corresponding .js files. (Exludes .json files)
 * `options.nameToKey(name)` returns a key to use in the tree object for the given file or folder name; the default implementation strips the file extension and replaces any non-identifier characters with underscores.
 
 Additionally, `options.readdirSync(directory)` and `options.isDirectory(path)` can be provided to override the standard behavior of reading from the file system.
@@ -123,10 +123,12 @@ Uses mocha, run `npm test` to execute tests.
         default filter callback
           ✓ should include .js files
           ✓ should include .coffee files that don't have corresponding .js files
+          ✓ should include registered extension files that don't have corresponding .js files
           ✓ should only include .js file when both .js and .coffee files exist
+          ✓ should only include .js file when both registered extension file and .js files exist
           ✓ should not include any other files
 
-    ✔ 23 tests complete (47ms)
+    ✔ 25 tests complete (47ms)
 
 
 License

--- a/lib/apitree.coffee
+++ b/lib/apitree.coffee
@@ -2,12 +2,20 @@
 fs   = require 'fs'
 Path = require 'path'
 
+extensions = () ->
+  if require?.extensions
+    (k for k,v of require.extensions when k != '.json')
+  else
+    ['.coffee']
+
 exports.createApiTree = createApiTree = (directory, options={}) ->
   options.loadItem    ||= require
   options.nameToKey   ||= (name) -> name .split('.')[0] .replace(/_*\W+_*/g, '_')
   options.readdirSync ||= (path) -> fs.readdirSync(path)
   options.isDirectory ||= (path) -> fs.lstatSync(path).isDirectory()
-  options.filter      ||= (name, names) -> name.match(/\.js$/) or (name.match(/\.coffee$/) and not (name.replace(/\.coffee$/, '.js') in names))
+  options.filter      ||= (name, names) ->
+    ext = Path.extname(name)
+    return ext == '.js' or (ext in extensions() and not (Path.basename(name, ext).concat('.js') in names))
 
   tree = {}
 

--- a/test/apitree_test.coffee
+++ b/test/apitree_test.coffee
@@ -140,14 +140,20 @@ describe "API tree", ->
 
   describe "default filter callback", ->
 
+    require.extensions['.tjs'] = require.extensions['.js']
+
     tree = T {
       'foo.js'     : ['xx']
       'bar.js'     : ['yy']
       'foo.txt'    : ['zz']
-      'Rakefile'   : ['rr'],
+      'Rakefile'   : ['rr']
       'boz.coffee' : ['cc']
       'both.js'    : ['bb']
       'both.coffee': ['BB']
+      'alien.tjs'  : ['aa']
+      'alienC.js'  : ['ll']
+      'alienC.tjs' : ['LL']
+      'data.json'  : ['dd']
     }, {nameToKey: (name) -> name}
 
     it "should include .js files", ->
@@ -157,10 +163,18 @@ describe "API tree", ->
     it "should include .coffee files that don't have corresponding .js files", ->
       assert.ok 'boz.coffee' of tree
 
+    it "should include registered extension files that don't have corresponding .js files", ->
+      assert.ok 'alien.tjs' of tree
+
     it "should only include .js file when both .js and .coffee files exist", ->
       assert.ok 'both.js' of tree
       assert.ok !('both.coffee' of tree)
 
+    it "should only include .js file when both registered extension file and .js files exist", ->
+      assert.ok 'alienC.js' of tree
+      assert.ok !('alienC.tjs' of tree)
+
     it "should not include any other files", ->
       assert.ok !('Rakefile' of tree)
       assert.ok !('foo.txt' of tree)
+      assert.ok !('data.json' of tree)

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,2 @@
 --reporter spec
+--compilers coffee:coffee-script


### PR DESCRIPTION
Hi.

I am using the nice SocketStream framework in combination with a coffee-script derivative called [LiveScript](http://gkz.github.com/LiveScript/). I would very much like to work directly with LiveScript files on the server side and as SocketStream uses apitree to load and build the sever side api, it would be great if you could update apitree.js to allow loading of modules with any registered module extension (in require.extensions).

I originally opened a pull request towards SocketStream [#254](https://github.com/socketstream/socketstream/pull/254) to have it use the apitree filter option, but have since realized that the change belongs in apitree, allowing others users of apitree to benefit from this, while at the same time simplifying the impact on SocketStream.

I have put together this pull request which implements the feature. It includes the change to the default filter, updated spec tests and updates to doc to reflect the change. I have run the tests on node.js v0.8.2 and v0.6.19. I tried running the tests on v0.4.12 but I couldn't get the installed mocha to behave. I have done some manual testing on node 0.4 to check that the code should work there.

I hope you will accept this request and publish a new version of apitree.js, Fell free to ask for changes or more tests.

Kind regards
Mads
